### PR TITLE
Reporting spans via HTTP (thrift)

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -5,35 +5,35 @@
 /*
 Package jaeger provides a monkit plugin for sending traces to Jaeger Agent.
 
-Example usage
+# Example usage
 
 Your main method gets set up something like this:
 
-  package main
+	  package main
 
-  import (
-	  "net/http"
+	  import (
+		  "net/http"
 
-	  jaeger "storj.io/monkit-jaeger"
-	  "github.com/spacemonkeygo/monkit/v3"
-	  "github.com/spacemonkeygo/monkit/v3/environment"
-	  "github.com/spacemonkeygo/monkit/v3/present"
-  )
+		  jaeger "storj.io/monkit-jaeger"
+		  "github.com/spacemonkeygo/monkit/v3"
+		  "github.com/spacemonkeygo/monkit/v3/environment"
+		  "github.com/spacemonkeygo/monkit/v3/present"
+	  )
 
-  func main() {
-	  environment.Register(monkit.Default)
-	  collector, err := jaeger.NewUDPCollector("zipkin.whatever:9042", 200, "service name", []jaeger.Tag{
-		  jaeger.Tag{
-			  ....
+	  func main() {
+		  environment.Register(monkit.Default)
+		  collector, err := jaeger.NewThriftCollector("zipkin.whatever:9042", 200, "service name", []jaeger.Tag{
+			  jaeger.Tag{
+				  ....
+			  }
+		  })
+		  if err != nil {
+			  panic(err)
 		  }
-	  })
-	  if err != nil {
-		  panic(err)
-	  }
-	  jaeger.RegisterJaeger(monkit.Default, collector, jaeger.Options{
-		  Fraction: 1})
+		  jaeger.RegisterJaeger(monkit.Default, collector, jaeger.Options{
+			  Fraction: 1})
 
-		...
-  }
+			...
+	  }
 */
 package jaeger // import "storj.io/monkit-jaeger"

--- a/go.sum
+++ b/go.sum
@@ -190,7 +190,6 @@ go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1
 golang.org/x/build v0.0.0-20190111050920-041ab4dc3f9d/go.mod h1:OWs+y06UdEOHN4y+MfF/py+xQ/tYqIWW03b70/CG9Rw=
 golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/http.go
+++ b/http.go
@@ -1,0 +1,66 @@
+// Copyright (C) 2020 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package jaeger
+
+import (
+	"context"
+	"io"
+	"net/http"
+
+	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/zeebo/errs"
+	"go.uber.org/zap"
+
+	"storj.io/monkit-jaeger/gen-go/jaeger"
+)
+
+// HTTPTransport sends Jaeger spans via HTTP.
+type HTTPTransport struct {
+	log  *zap.Logger
+	addr string
+}
+
+var _ Transport = &HTTPTransport{}
+
+// OpenHTTPTransport creates a new HTTP transport.
+func OpenHTTPTransport(ctx context.Context, log *zap.Logger, agentAddr string) (*HTTPTransport, error) {
+	return &HTTPTransport{
+		log:  log,
+		addr: agentAddr,
+	}, nil
+
+}
+
+// Send sends out the Jaeger spans.
+func (u *HTTPTransport) Send(ctx context.Context, batch *jaeger.Batch) error {
+	t := thrift.NewTMemoryBuffer()
+	p := thrift.NewTBinaryProtocolTransport(t)
+	err := batch.Write(p)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", u.addr, nil)
+	if err != nil {
+		return errs.Wrap(err)
+	}
+	req.Header.Add("Content-Type", "application/x-thrift")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return errs.Wrap(err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode >= 400 {
+		raw, _ := io.ReadAll(resp.Body)
+		return errs.New("Error on posting data to jaeger. HTTP %s: %s", resp.Status, string(raw))
+	}
+	return nil
+}
+
+// Close closes the transport.
+func (u *HTTPTransport) Close() {
+
+}

--- a/mockagent_test.go
+++ b/mockagent_test.go
@@ -123,8 +123,8 @@ func (m *MockAgent) Serve() error {
 
 	handler := agent.NewAgentProcessor(m)
 	protocolFact := thrift.NewTCompactProtocolFactory()
-	trans := thrift.NewTMemoryBufferLen(maxPacketSize)
-	buf := make([]byte, maxPacketSize)
+	trans := thrift.NewTMemoryBufferLen(maxPacketSizeUDP)
+	buf := make([]byte, maxPacketSizeUDP)
 
 	close(m.started)
 	for !m.isClosed() {

--- a/register_test.go
+++ b/register_test.go
@@ -85,7 +85,7 @@ func TestRegisterJaeger(t *testing.T) {
 		test := test
 		t.Run(test.e.operationName, func(t *testing.T) {
 			withAgent(t, func(agent *MockAgent) {
-				withCollector(ctx, t, agent.Addr(), 0, time.Nanosecond, func(collector *UDPCollector) {
+				withCollector(ctx, t, agent.Addr(), 0, time.Nanosecond, func(collector *ThriftCollector) {
 					r := monkit.NewRegistry()
 					RegisterJaeger(r, collector, Options{
 						Fraction: 1,

--- a/thrift.go
+++ b/thrift.go
@@ -16,7 +16,6 @@ import (
 	"go.uber.org/zap"
 
 	"storj.io/common/context2"
-	"storj.io/monkit-jaeger/gen-go/agent"
 	"storj.io/monkit-jaeger/gen-go/jaeger"
 )
 
@@ -59,7 +58,6 @@ type ThriftCollector struct {
 	ch            chan *jaeger.Span
 	flushInterval time.Duration
 	process       *jaeger.Process // the information of which process is sending the spans
-	client        *agent.AgentClient
 
 	maxSpanBytes     int                   // the max bytes spans can take up to make sure we don't exceed maxPacketSize
 	maxPacketSize    int                   // the max number of bytes this instance of UDPCollector allows for a single UDP packet

--- a/thrift.go
+++ b/thrift.go
@@ -48,7 +48,7 @@ const (
 )
 
 // ThriftCollector matches the TraceCollector interface, but sends serialized
-// jaeger.Span objects with the help of the registered tansport, instead of the Scribe protocol. See
+// jaeger.Span objects with the help of the registered transport, instead of the Scribe protocol. See
 // RedirectPackets for the UDP server-side code.
 type ThriftCollector struct {
 	mu               sync.Mutex

--- a/transport.go
+++ b/transport.go
@@ -1,0 +1,6 @@
+package jaeger
+
+type Transport interface {
+	Write([]byte) error
+	Close()
+}

--- a/transport.go
+++ b/transport.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2023 Storj Labs, Inc.
+// See LICENSE for copying information.
+
 package jaeger
 
 import (

--- a/transport.go
+++ b/transport.go
@@ -1,6 +1,16 @@
 package jaeger
 
+import (
+	"context"
+
+	"storj.io/monkit-jaeger/gen-go/jaeger"
+)
+
+// Transport defines how the span batches are sent.
 type Transport interface {
-	Write([]byte) error
+	// Send sends out the Jaeger spans.
+	Send(ctx context.Context, batch *jaeger.Batch) error
+
+	// Close closes the transport.
 	Close()
 }

--- a/trhift.go
+++ b/trhift.go
@@ -1,0 +1,293 @@
+// Copyright (C) 2020 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package jaeger
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/zeebo/errs"
+	"go.uber.org/zap"
+	"storj.io/common/context2"
+	"storj.io/monkit-jaeger/gen-go/agent"
+	"storj.io/monkit-jaeger/gen-go/jaeger"
+)
+
+const (
+	// max size of a packet we can send to jaeger-agent in one request.
+	// see: https://github.com/jaegertracing/jaeger-client-go/blob/1db6ae67694d13f4ecb454cd65b40034a687118a/utils/udp_client.go#L30
+	maxPacketSize = 1000
+
+	// jaeger-client-go has calculation for how this number is set.
+	// see: https://github.com/jaegertracing/jaeger-client-go/blob/e75ea75c424f3127125aad39056a2718a3b5aa1d/transport_udp.go#L33
+	emitBatchOverhead = 30
+
+	// defaultQueueSize is the default size of the span queue.
+	defaultQueueSize = 1000
+
+	// defaultFlushInterval is the default interval to send data on ticker.
+	defaultFlushInterval = 15 * time.Second
+
+	// estimateSpanSize is the estimation size of a span we pre-allocate for pricise span size calculation.
+	estimateSpanSize = 600
+)
+
+// ThriftCollector matches the TraceCollector interface, but sends serialized
+// jaeger.Span objects with the help of the registered tansport, instead of the Scribe protocol. See
+// RedirectPackets for the UDP server-side code.
+type ThriftCollector struct {
+	mu               sync.Mutex
+	spansToSend      []*jaeger.Span        // the spans waiting to be send to the agent
+	thriftBuffer     *thrift.TMemoryBuffer // the buffer where we encode data to send to the agent
+	currentSpanBytes int                   // the current bytes used by spans when they are encoded into thrift buffer
+
+	log           *zap.Logger
+	ch            chan *jaeger.Span
+	flushInterval time.Duration
+	process       *jaeger.Process // the information of which process is sending the spans
+	client        *agent.AgentClient
+
+	maxSpanBytes     int                   // the max bytes spans can take up to make sure we don't exceed maxPacketSize
+	maxPacketSize    int                   // the max number of bytes this instance of UDPCollector allows for a single UDP packet
+	spanSizeBuffer   *thrift.TMemoryBuffer // spanSizeBuffer helps us calculate the size of the span when thrift-encoded
+	thriftProtocol   thrift.TProtocol
+	spanSizeProtocol thrift.TProtocol
+	batchSeqNo       int64
+	agentAddr        string
+}
+
+// NewThriftCollector creates a UDPCollector that sends packets to jaeger agent.
+func NewThriftCollector(log *zap.Logger, agentAddr string, serviceName string, tags []Tag, packetSize, queueSize int, flushInterval time.Duration) (
+	*ThriftCollector, error) {
+
+	if packetSize == 0 {
+		packetSize = maxPacketSize
+	}
+
+	if queueSize == 0 {
+		queueSize = defaultQueueSize
+	}
+
+	if flushInterval == 0 {
+		flushInterval = defaultFlushInterval
+	}
+
+	thriftBuffer := thrift.NewTMemoryBufferLen(packetSize)
+	spanSizeBuffer := thrift.NewTMemoryBufferLen(estimateSpanSize)
+	protocolFactory := thrift.NewTCompactProtocolFactory()
+	thriftProtocol := protocolFactory.GetProtocol(thriftBuffer)
+	spanSizeProtocol := protocolFactory.GetProtocol(spanSizeBuffer)
+	client := agent.NewAgentClientFactory(thriftBuffer, protocolFactory)
+
+	jaegerTags := make([]*jaeger.Tag, 0, len(tags))
+	for _, tag := range tags {
+		j, err := tag.BuildJaegerThrift()
+		if err != nil {
+			log.Debug("failed to convert to jaeger tags", zap.Error(err))
+			continue
+		}
+		jaegerTags = append(jaegerTags, j)
+	}
+
+	jaegerProcess := &jaeger.Process{
+		ServiceName: serviceName,
+		Tags:        jaegerTags,
+	}
+
+	processByteSize, err := calculateThriftSize(jaegerProcess, spanSizeBuffer, spanSizeProtocol)
+	if err != nil {
+		return nil, errs.Wrap(err)
+	}
+
+	return &ThriftCollector{
+		log:              log.Named("tracing collector"),
+		ch:               make(chan *jaeger.Span, queueSize),
+		client:           client,
+		flushInterval:    flushInterval,
+		maxSpanBytes:     packetSize - emitBatchOverhead - processByteSize,
+		spanSizeBuffer:   spanSizeBuffer,
+		thriftBuffer:     thriftBuffer,
+		thriftProtocol:   thriftProtocol,
+		spanSizeProtocol: spanSizeProtocol,
+		maxPacketSize:    packetSize,
+		process:          jaegerProcess,
+		agentAddr:        agentAddr,
+	}, nil
+}
+
+// Run reads spans off the queue and appends them to the buffer. When the
+// buffer fills up, it flushes. It also flushes on a jittered interval.
+func (c *ThriftCollector) Run(ctx context.Context) {
+	c.log.Debug("started")
+	defer c.log.Debug("stopped")
+
+	tp, err := OpenUDPTransport(ctx, c.log, c.agentAddr, c.maxPacketSize)
+	if err != nil {
+		return
+	}
+	defer tp.Close()
+
+	ticker := time.NewTicker(jitter(c.flushInterval))
+	defer ticker.Stop()
+
+	for {
+		select {
+		case s := <-c.ch:
+			err := c.handleSpan(ctx, s, tp)
+			if err != nil {
+				mon.Counter("jaeger_span_handling_failure").Inc(1)
+				c.log.Debug("failed to handle span", zap.Error(err))
+			}
+		case <-ticker.C:
+			if err := c.Send(ctx, tp); err != nil {
+				c.log.Debug("failed to send on ticker", zap.Error(err))
+			}
+			ticker.Reset(jitter(c.flushInterval))
+			// clear ticker
+			select {
+			case <-ticker.C:
+			default:
+			}
+		case <-ctx.Done():
+			// drain the channel on shutdown
+			left := len(c.ch)
+			ctxWithoutCancel := context2.WithoutCancellation(ctx)
+			for i := 0; i < left; i++ {
+				s := <-c.ch
+				err := c.handleSpan(ctxWithoutCancel, s, tp)
+				if err != nil {
+					mon.Counter("jaeger_span_handling_failure").Inc(1)
+					c.log.Debug("failed to handle span", zap.Error(err))
+				}
+			}
+			if err := c.send(ctxWithoutCancel, tp); err != nil {
+				c.log.Debug("failed to send on close", zap.Error(err))
+			}
+			return
+		}
+	}
+}
+
+// Close gracefully shutdown the underlying udp connection, after remaining messages are sent out.
+// Deprecated: cancelling the context of run will close the connection.
+func (c *ThriftCollector) Close() error {
+	return nil
+}
+
+// handleSpan adds a new span into the buffer.
+func (c *ThriftCollector) handleSpan(ctx context.Context, s *jaeger.Span, transport Transport) (err error) {
+	spanSize, err := calculateThriftSize(s, c.spanSizeBuffer, c.spanSizeProtocol)
+	if err != nil {
+		return errs.Wrap(err)
+	}
+
+	if spanSize > c.maxSpanBytes {
+		mon.Counter("jaeger_span_too_large").Inc(1)
+		return errs.New("span is too large. Expected no bigger than %d, got %d", c.maxSpanBytes, spanSize)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.currentSpanBytes+spanSize > c.maxSpanBytes {
+		if err := c.send(ctx, transport); err != nil {
+			return errs.Wrap(err)
+		}
+	}
+
+	c.currentSpanBytes += spanSize
+	c.spansToSend = append(c.spansToSend, s)
+
+	return nil
+}
+
+// Send sends traces to jaeger agent.
+func (c *ThriftCollector) Send(ctx context.Context, transport Transport) (err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.send(ctx, transport)
+}
+
+func (c *ThriftCollector) send(ctx context.Context, transport Transport) (err error) {
+	if len(c.spansToSend) == 0 {
+		return nil
+	}
+
+	c.batchSeqNo++
+	batchSeqNo := c.batchSeqNo
+	batch := &jaeger.Batch{
+		Process: c.process,
+		Spans:   c.spansToSend,
+		SeqNo:   &batchSeqNo,
+	}
+
+	// Reset the thriftBuffer so that EmitBatch can write onto an empty buffer
+	c.thriftBuffer.Reset()
+	if err := c.client.EmitBatch(ctx, batch); err != nil {
+		return errs.Wrap(err)
+	}
+
+	// Reset the span buffer no matter we succeed or not to prevent getting into an infinite loop
+	// it probably is ok if we lose one batch of trace since these are just metrics data
+	defer c.resetSpanBuffer()
+	if c.thriftBuffer.Len() > c.maxPacketSize {
+		mon.Counter("jaeger_exceeds_packet_size").Inc(1)
+		return fmt.Errorf("data does not fit within one UDP packet; size %d, max %d, spans %d",
+			c.thriftBuffer.Len(), c.maxPacketSize, len(batch.Spans))
+	}
+
+	err = transport.Write(c.thriftBuffer.Bytes())
+	if err != nil {
+		return errs.Wrap(err)
+	}
+
+	return nil
+}
+
+// Collect takes a jaeger.Span object, serializes it, and sends it to the
+// configured collector_addr.
+func (c *ThriftCollector) Collect(span *jaeger.Span) {
+	select {
+	case c.ch <- span:
+	default:
+		mon.Counter("jaeger_buffer_full").Inc(1)
+	}
+}
+
+// Len returns the amount of spans in the queue currently.
+// This is only exposed for testing purpose.
+func (c *ThriftCollector) Len() int {
+	return len(c.ch)
+}
+
+func (c *ThriftCollector) resetSpanBuffer() {
+	for i := range c.spansToSend {
+		c.spansToSend[i] = nil
+	}
+	c.spansToSend = c.spansToSend[:0]
+	c.currentSpanBytes = 0
+}
+
+func calculateThriftSize(data thrift.TStruct, buffer *thrift.TMemoryBuffer, protocol thrift.TProtocol) (int, error) {
+	buffer.Reset()
+	err := data.Write(protocol)
+	if err != nil {
+		return 0, err
+	}
+
+	return buffer.Len(), nil
+}
+
+func jitter(t time.Duration) time.Duration {
+	nanos := rand.NormFloat64()*float64(t/4) + float64(t)
+	if nanos <= 0 {
+		nanos = 1
+	}
+	return time.Duration(nanos)
+}

--- a/udp.go
+++ b/udp.go
@@ -5,310 +5,52 @@ package jaeger
 
 import (
 	"context"
-	"fmt"
-	"math/rand"
-	"net"
-	"sync"
-	"time"
-
-	"github.com/apache/thrift/lib/go/thrift"
-	"github.com/zeebo/errs"
 	"go.uber.org/zap"
-
-	"storj.io/common/context2"
-	"storj.io/monkit-jaeger/gen-go/agent"
-	"storj.io/monkit-jaeger/gen-go/jaeger"
+	"net"
 )
 
-const (
-	// max size of UDP packet we can send to jaeger-agent.
-	// see: https://github.com/jaegertracing/jaeger-client-go/blob/1db6ae67694d13f4ecb454cd65b40034a687118a/utils/udp_client.go#L30
-	maxPacketSize = 1000
-
-	// jaeger-client-go has calculation for how this number is set.
-	// see: https://github.com/jaegertracing/jaeger-client-go/blob/e75ea75c424f3127125aad39056a2718a3b5aa1d/transport_udp.go#L33
-	emitBatchOverhead = 30
-
-	// defaultQueueSize is the default size of the span queue.
-	defaultQueueSize = 1000
-
-	// defaultFlushInterval is the default interval to send data on ticker.
-	defaultFlushInterval = 15 * time.Second
-
-	// estimateSpanSize is the estimation size of a span we pre-allocate for pricise span size calculation.
-	estimateSpanSize = 600
-)
-
-// UDPCollector matches the TraceCollector interface, but sends serialized
-// jaeger.Span objects over UDP, instead of the Scribe protocol. See
-// RedirectPackets for the UDP server-side code.
-type UDPCollector struct {
-	mu               sync.Mutex
-	spansToSend      []*jaeger.Span        // the spans waiting to be send to the agent
-	thriftBuffer     *thrift.TMemoryBuffer // the buffer where we encode data to send to the agent
-	currentSpanBytes int                   // the current bytes used by spans when they are encoded into thrift buffer
-
-	log              *zap.Logger
-	ch               chan *jaeger.Span
-	flushInterval    time.Duration
-	process          *jaeger.Process // the information of which process is sending the spans
-	client           *agent.AgentClient
-	conn             net.Conn
-	maxSpanBytes     int                   // the max bytes spans can take up to make sure we don't exceed maxPacketSize
-	maxPacketSize    int                   // the max number of bytes this instance of UDPCollector allows for a single UDP packet
-	spanSizeBuffer   *thrift.TMemoryBuffer // spanSizeBuffer helps us calculate the size of the span when thrift-encoded
-	thriftProtocol   thrift.TProtocol
-	spanSizeProtocol thrift.TProtocol
-	batchSeqNo       int64
-	agentAddr        string
+type UDPTransport struct {
+	conn *net.UDPConn
+	log  *zap.Logger
 }
 
-// NewUDPCollector creates a UDPCollector that sends packets to jaeger agent.
-func NewUDPCollector(log *zap.Logger, agentAddr string, serviceName string, tags []Tag, packetSize, queueSize int, flushInterval time.Duration) (
-	*UDPCollector, error) {
+var _ Transport = &UDPTransport{}
 
-	if packetSize == 0 {
-		packetSize = maxPacketSize
-	}
-
-	if queueSize == 0 {
-		queueSize = defaultQueueSize
-	}
-
-	if flushInterval == 0 {
-		flushInterval = defaultFlushInterval
-	}
-
-	thriftBuffer := thrift.NewTMemoryBufferLen(packetSize)
-	spanSizeBuffer := thrift.NewTMemoryBufferLen(estimateSpanSize)
-	protocolFactory := thrift.NewTCompactProtocolFactory()
-	thriftProtocol := protocolFactory.GetProtocol(thriftBuffer)
-	spanSizeProtocol := protocolFactory.GetProtocol(spanSizeBuffer)
-	client := agent.NewAgentClientFactory(thriftBuffer, protocolFactory)
-
-	jaegerTags := make([]*jaeger.Tag, 0, len(tags))
-	for _, tag := range tags {
-		j, err := tag.BuildJaegerThrift()
-		if err != nil {
-			log.Debug("failed to convert to jaeger tags", zap.Error(err))
-			continue
-		}
-		jaegerTags = append(jaegerTags, j)
-	}
-
-	jaegerProcess := &jaeger.Process{
-		ServiceName: serviceName,
-		Tags:        jaegerTags,
-	}
-
-	processByteSize, err := calculateThriftSize(jaegerProcess, spanSizeBuffer, spanSizeProtocol)
-	if err != nil {
-		return nil, errs.Wrap(err)
-	}
-
-	return &UDPCollector{
-		log:              log.Named("tracing collector"),
-		ch:               make(chan *jaeger.Span, queueSize),
-		client:           client,
-		flushInterval:    flushInterval,
-		maxSpanBytes:     packetSize - emitBatchOverhead - processByteSize,
-		spanSizeBuffer:   spanSizeBuffer,
-		thriftBuffer:     thriftBuffer,
-		thriftProtocol:   thriftProtocol,
-		spanSizeProtocol: spanSizeProtocol,
-		maxPacketSize:    packetSize,
-		process:          jaegerProcess,
-		agentAddr:        agentAddr,
-	}, nil
-}
-
-// Run reads spans off the queue and appends them to the buffer. When the
-// buffer fills up, it flushes. It also flushes on a jittered interval.
-func (c *UDPCollector) Run(ctx context.Context) {
-	c.log.Debug("started")
-	defer c.log.Debug("stopped")
+func OpenUDPTransport(ctx context.Context, log *zap.Logger, agentAddr string, maxPacketSize int) (*UDPTransport, error) {
 	var err error
 
 	dialer := net.Dialer{}
-	c.conn, err = dialer.DialContext(ctx, "udp", c.agentAddr)
+	conn, err := dialer.DialContext(ctx, "udp", agentAddr)
 	if err != nil {
-		c.log.Debug("failed open  UDP connection to Jaeger", zap.Error(err))
-		return
+		log.Debug("failed open  UDP connection to Jaeger", zap.Error(err))
+		return nil, err
 	}
-	defer func() {
-		err := c.conn.Close()
-		if err != nil {
-			c.log.Debug("failed to close Jaeger UDP connection", zap.Error(err))
-		}
-	}()
 
-	udpConn, ok := c.conn.(*net.UDPConn)
+	udpConn, ok := conn.(*net.UDPConn)
 	if !ok {
-		c.log.Debug("Connection type mismatch", zap.Error(err))
-		return
+		log.Debug("Connection type mismatch", zap.Error(err))
+		return nil, err
 	}
 
-	if err := udpConn.SetWriteBuffer(c.maxPacketSize); err != nil {
-		c.log.Debug("failed to set max packet size on Jaeger UDP connection", zap.Error(err), zap.Int("maxPacketSize", c.maxPacketSize))
-		return
+	if err := udpConn.SetWriteBuffer(maxPacketSize); err != nil {
+		log.Debug("failed to set max packet size on Jaeger UDP connection", zap.Error(err), zap.Int("maxPacketSize", maxPacketSize))
+		return nil, err
 	}
+	return &UDPTransport{
+		log:  log,
+		conn: udpConn,
+	}, nil
 
-	ticker := time.NewTicker(jitter(c.flushInterval))
-	defer ticker.Stop()
-
-	for {
-		select {
-		case s := <-c.ch:
-			err := c.handleSpan(ctx, s)
-			if err != nil {
-				mon.Counter("jaeger_span_handling_failure").Inc(1)
-				c.log.Debug("failed to handle span", zap.Error(err))
-			}
-		case <-ticker.C:
-			if err := c.Send(ctx); err != nil {
-				c.log.Debug("failed to send on ticker", zap.Error(err))
-			}
-			ticker.Reset(jitter(c.flushInterval))
-			// clear ticker
-			select {
-			case <-ticker.C:
-			default:
-			}
-		case <-ctx.Done():
-			// drain the channel on shutdown
-			left := len(c.ch)
-			ctxWithoutCancel := context2.WithoutCancellation(ctx)
-			for i := 0; i < left; i++ {
-				s := <-c.ch
-				err := c.handleSpan(ctxWithoutCancel, s)
-				if err != nil {
-					mon.Counter("jaeger_span_handling_failure").Inc(1)
-					c.log.Debug("failed to handle span", zap.Error(err))
-				}
-			}
-			if err := c.send(ctxWithoutCancel); err != nil {
-				c.log.Debug("failed to send on close", zap.Error(err))
-			}
-			return
-		}
-	}
 }
 
-// Close gracefully shutdown the underlying udp connection, after remaining messages are sent out.
-// Deprecated: cancelling the context of run will close the connection.
-func (c *UDPCollector) Close() error {
-	return nil
+func (u *UDPTransport) Write(bytes []byte) error {
+	_, err := u.conn.Write(bytes)
+	return err
 }
 
-// handleSpan adds a new span into the buffer.
-func (c *UDPCollector) handleSpan(ctx context.Context, s *jaeger.Span) (err error) {
-	spanSize, err := calculateThriftSize(s, c.spanSizeBuffer, c.spanSizeProtocol)
+func (u *UDPTransport) Close() {
+	err := u.conn.Close()
 	if err != nil {
-		return errs.Wrap(err)
+		u.log.Debug("failed to close Jaeger UDP connection", zap.Error(err))
 	}
-
-	if spanSize > c.maxSpanBytes {
-		mon.Counter("jaeger_span_too_large").Inc(1)
-		return errs.New("span is too large. Expected no bigger than %d, got %d", c.maxSpanBytes, spanSize)
-	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.currentSpanBytes+spanSize > c.maxSpanBytes {
-		if err := c.send(ctx); err != nil {
-			return errs.Wrap(err)
-		}
-	}
-
-	c.currentSpanBytes += spanSize
-	c.spansToSend = append(c.spansToSend, s)
-
-	return nil
-}
-
-// Send sends traces to jaeger agent.
-func (c *UDPCollector) Send(ctx context.Context) (err error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	return c.send(ctx)
-}
-
-func (c *UDPCollector) send(ctx context.Context) (err error) {
-	if len(c.spansToSend) == 0 {
-		return nil
-	}
-
-	c.batchSeqNo++
-	batchSeqNo := c.batchSeqNo
-	batch := &jaeger.Batch{
-		Process: c.process,
-		Spans:   c.spansToSend,
-		SeqNo:   &batchSeqNo,
-	}
-
-	// Reset the thriftBuffer so that EmitBatch can write onto an empty buffer
-	c.thriftBuffer.Reset()
-	if err := c.client.EmitBatch(ctx, batch); err != nil {
-		return errs.Wrap(err)
-	}
-
-	// Reset the span buffer no matter we succeed or not to prevent getting into an infinite loop
-	// it probably is ok if we lose one batch of trace since these are just metrics data
-	defer c.resetSpanBuffer()
-	if c.thriftBuffer.Len() > c.maxPacketSize {
-		mon.Counter("jaeger_exceeds_packet_size").Inc(1)
-		return fmt.Errorf("data does not fit within one UDP packet; size %d, max %d, spans %d",
-			c.thriftBuffer.Len(), c.maxPacketSize, len(batch.Spans))
-	}
-
-	_, err = c.conn.Write(c.thriftBuffer.Bytes())
-	if err != nil {
-		return errs.Wrap(err)
-	}
-
-	return nil
-}
-
-// Collect takes a jaeger.Span object, serializes it, and sends it to the
-// configured collector_addr.
-func (c *UDPCollector) Collect(span *jaeger.Span) {
-	select {
-	case c.ch <- span:
-	default:
-		mon.Counter("jaeger_buffer_full").Inc(1)
-	}
-}
-
-// Len returns the amount of spans in the queue currently.
-// This is only exposed for testing purpose.
-func (c *UDPCollector) Len() int {
-	return len(c.ch)
-}
-
-func (c *UDPCollector) resetSpanBuffer() {
-	for i := range c.spansToSend {
-		c.spansToSend[i] = nil
-	}
-	c.spansToSend = c.spansToSend[:0]
-	c.currentSpanBytes = 0
-}
-
-func calculateThriftSize(data thrift.TStruct, buffer *thrift.TMemoryBuffer, protocol thrift.TProtocol) (int, error) {
-	buffer.Reset()
-	err := data.Write(protocol)
-	if err != nil {
-		return 0, err
-	}
-
-	return buffer.Len(), nil
-}
-
-func jitter(t time.Duration) time.Duration {
-	nanos := rand.NormFloat64()*float64(t/4) + float64(t)
-	if nanos <= 0 {
-		nanos = 1
-	}
-	return time.Duration(nanos)
 }

--- a/udp_test.go
+++ b/udp_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func withCollector(ctx context.Context, t *testing.T, agentAddr string,
-	packetSize int, interval time.Duration, f func(*UDPCollector)) {
+	packetSize int, interval time.Duration, f func(*ThriftCollector)) {
 
 	// if the interval is 0 (default), make it incredibly so long it's
 	// impossible for it to trigger during the test
@@ -26,7 +26,7 @@ func withCollector(ctx context.Context, t *testing.T, agentAddr string,
 		interval = 24 * time.Hour
 	}
 
-	collector, err := NewUDPCollector(zaptest.NewLogger(t), agentAddr, "test", nil, packetSize, 0, interval)
+	collector, err := NewThriftCollector(zaptest.NewLogger(t), agentAddr, "test", nil, packetSize, 0, interval)
 	require.NoError(t, err)
 
 	var eg errgroup.Group
@@ -49,7 +49,7 @@ func withCollector(ctx context.Context, t *testing.T, agentAddr string,
 func TestSendIsTriggeredByInterval(t *testing.T) {
 	ctx := testcontext.New(t)
 	withAgent(t, func(mock *MockAgent) {
-		withCollector(ctx, t, mock.Addr(), 99999999, time.Nanosecond, func(collector *UDPCollector) {
+		withCollector(ctx, t, mock.Addr(), 99999999, time.Nanosecond, func(collector *ThriftCollector) {
 
 			// let's fill it with a one span
 			collector.Collect(&jaeger.Span{
@@ -69,7 +69,7 @@ func TestSendIsTriggeredByInterval(t *testing.T) {
 func TestSendIsTriggeredByManySpans(t *testing.T) {
 	ctx := testcontext.New(t)
 	withAgent(t, func(mock *MockAgent) {
-		withCollector(ctx, t, mock.Addr(), 200, 0, func(collector *UDPCollector) {
+		withCollector(ctx, t, mock.Addr(), 200, 0, func(collector *ThriftCollector) {
 
 			// let's fill it with a number of spans
 			for i := 0; i < 100; i++ {
@@ -91,7 +91,7 @@ func TestSendIsTriggeredByManySpans(t *testing.T) {
 func TestUDPCollector(t *testing.T) {
 	ctx := testcontext.New(t)
 	withAgent(t, func(mock *MockAgent) {
-		withCollector(ctx, t, mock.Addr(), 0, time.Nanosecond, func(collector *UDPCollector) {
+		withCollector(ctx, t, mock.Addr(), 0, time.Nanosecond, func(collector *ThriftCollector) {
 			span := &jaeger.Span{
 				TraceIdLow:    monkit.NewId(),
 				SpanId:        monkit.NewId(),


### PR DESCRIPTION
The current code sends out Jaeger spans via UDP (encoded with Thrift). But we don't always receive all the spans. 

Seems to be useful to support sending out spans via HTTP (encoded with Thrift) if more reliable transport is required.

In the first commit, the logic of encoding/buffering is separated from the transport. The second commit implements the HTTP transport. Can be tested using `--trace-addr http://localhost:14268` + uplink.